### PR TITLE
Tiny update: Pre no longer required for distorm3 install

### DIFF
--- a/rekall/Dockerfile
+++ b/rekall/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y \
   byacc \
   git && \
 
-  pip install -q --pre distorm3 && \
+  pip install -q distorm3 && \
   git clone https://github.com/plusvic/yara.git && \
   cd yara && \
   bash build.sh && \


### PR DESCRIPTION
In a GRR install [issue](https://github.com/google/grr/issues/36) elsewhere on GitHub, @brifordwylie chased down the distorm3 author and got that fixed upstream so that we don't have to tiptoe around it in pip, yay.