### PR TITLE
Add 2 missing backslashes in radare2/Dockerfile

### DIFF
--- a/radare2/Dockerfile
+++ b/radare2/Dockerfile
@@ -33,10 +33,10 @@ RUN apt-get update && apt-get install -y \
   g++ \
   make \
   pkg-config \
-  glib-2.0
+  glib-2.0 \
   python-gobject-dev \
   valgrind \
-  gdb &&
+  gdb && \
   rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r nonroot && \


### PR DESCRIPTION
Hi,

`docker build` fails due to the missing backslashes. Made a quick PR to solve it.

Thanks 