### PR TITLE
Errors on 'RUN bundle install' without this update

### DIFF
--- a/jsdetox/Dockerfile
+++ b/jsdetox/Dockerfile
@@ -7,7 +7,7 @@
 # Then, connect to http://localhost:3000 using your web browser.
 #
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Lenny Zeltser (@lennyzeltser, www.zeltser.com)
 
 USER root


### PR DESCRIPTION
```
Cloning into 'jsdetox'...
Removing intermediate container 94ed9e0480b6
 ---> 171d9908a06f
Step 9/15 : USER root
 ---> Running in 0eea0cc2d780
Removing intermediate container 0eea0cc2d780
 ---> 7dd4deeed671
Step 10/15 : WORKDIR /home/nonroot/jsdetox
Removing intermediate container d5e82dc27016
 ---> 1a71f206f308
Step 11/15 : RUN bundle install
 ---> Running in 4fac742e4c13
Fetching gem metadata from https://rubygems.org/...........
Fetching gem metadata from https://rubygems.org/..
Resolving dependencies...
Installing rake (12.3.1) 
Gem::InstallError: rake requires Ruby version >= 2.0.0.
An error occurred while installing rake (12.3.1), and Bundler cannot continue.
Make sure that `gem install rake -v '12.3.1'` succeeds before bundling.
The command '/bin/sh -c bundle install' returned a non-zero code: 5
```