### PR TITLE
Adding an updated rekall docker based on 18.04

### DIFF
--- a/rekall/Dockerfile
+++ b/rekall/Dockerfile
@@ -1,61 +1,47 @@
-#
-# This Docker image encapsulates the Rekall Memory Forensic Framework,
-# which is available at http://www.rekall-forensic.com.
-#
-# To run this image after installing Docker, use a command like this:
-#
-# sudo docker run --rm -it -v ~/files:/home/nonroot/files remnux/rekall bash
-#
-# then run "rekall" in the container with the desired parameters.
-#
-# Before running the command above, create the "files" directory on your host and 
-# make it world-accessible (e.g., "chmod a+xwr ~/files").
-#
-# To use Rekall's web console, invoke the container with the -p parameter to give
-# your host access to the container's TCP port 8000 like this:
-# 
-# sudo docker run --rm -it -p 8000:8000 -v ~/files:/home/nonroot/files remnux/rekall
-#
-# Then connect to http://localhost:8000 using a web browser from your host.
-#
+FROM ubuntu:bionic
 
-FROM ubuntu:14.04
-MAINTAINER Lenny Zeltser (@lennyzeltser, www.zeltser.com)
+LABEL version="1.3"
+LABEL description="Rekall docker based on Ubuntu 18.04 LTS"
+LABEL maintainer="https://github.com/digitalsleuth/rekall-docker"
 
 USER root
 RUN apt-get update && apt-get install -y \
-  python-dev \
+  virtualenv \
+  nano \
+  git \
+  python \
   python-pip \
-  libtool \
+  python-dev \
+  libssl-dev \
   automake \
+  make \
+  gcc \
+  flex \
+  libtool \
   bison \
-  git && \
-
-  pip install -q distorm3 && \
-  git clone https://github.com/plusvic/yara.git && \
-  cd yara && \
-  bash build.sh && \
-  make install && \
-  cd yara-python && \
-  python setup.py build && \
-  python setup.py install && \
-  cd ../.. && \
-  rm -rf yara && \
-  ldconfig && \
-
-  pip install -q gevent-websocket \
-    flask-sockets \
-    codegen \
-    acora \
-    pyelftools \
-    pycrypto && \
-
-  pip install rekall && \
-
-  apt-get remove -y --purge git automake libtool byacc && \
-  apt-get autoremove -y --purge && \
-  apt-get clean -y && \
+  pkg-config \
+  ncurses-dev && \
   rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade setuptools pip wheel readline future==0.16.0 pybindgen pyaff4==0.26.post6 && \
+  rm /usr/bin/pip && ln -s /usr/local/bin/pip /usr/bin/pip && \
+  pip install fastchunking pyopenssl && \
+  pip install -q distorm3 && \
+  git clone https://github.com/VirusTotal/yara.git && \
+  cd yara && \
+  bash bootstrap.sh && \
+  bash configure && \
+  make && \
+  make install && \
+  make check && \
+  echo "/usr/local/lib" >> /etc/ld.so.conf && \
+  ldconfig && \
+  cd .. && \
+  rm -rf yara && \
+  pip install rekall-agent rekall && \
+  apt-get autoremove -y --purge && \
+  apt-get clean -y
+
 
 RUN groupadd -r nonroot && \
   useradd -r -g nonroot -d /home/nonroot -s /sbin/nologin -c "Nonroot User" nonroot && \
@@ -64,6 +50,5 @@ RUN groupadd -r nonroot && \
 
 USER nonroot
 ENV HOME /home/nonroot
-ENV USER nonroot
 WORKDIR /home/nonroot
-CMD rekall webconsole --port 8000 --host $HOSTNAME
+ENV USER nonroot

--- a/rekall/README.md
+++ b/rekall/README.md
@@ -2,17 +2,10 @@
 
 This Dockerfile represents a Docker image that encapsulates the [Rekall Memory Forensic Framework][1]. To run this image after installing Docker, use a command like this:
 
-    sudo docker run --rm -it -v ~/files:/home/nonroot/files remnux/rekall bash
+    sudo docker run --rm -it -v <local_directory>:/home/nonroot/files remnux/rekall bash
 
 then run "`rekall`" in the container with the desired parameters.
 
-Before running the command above, create the "files" directory on your host and make it world-accessible (e.g., "`chmod a+xwr ~/files`").
-
-To use Rekall's web console, invoke the container with the `-p` parameter to give your host access to the container's TCP port 8000 like this:
-
-    sudo docker run --rm -it -p 8000:8000 -v ~/files:/home/nonroot/files remnux/rekall
-
-Then connect to http://localhost:8000 using a web browser from your host.
-
+Before running the command above, you can create the desired <local_directory> on your host and make it world-accessible (e.g., "`chmod a+xwr ~/files`").
 
   [1]: http://www.rekall-forensic.com


### PR DESCRIPTION
Built this a little while ago for someone in reddit who was having issues. Adds some updates, removes webconsole (no longer supported as far as I can tell).

If you want to test it, its already available as 'docker pull digitalsleuth/rekall-docker'. 