### PR TITLE
Updated jsdetox docker for 18.04

### DIFF
--- a/jsdetox/Dockerfile
+++ b/jsdetox/Dockerfile
@@ -3,12 +3,17 @@
 # from http://www.relentless-coding.com/projects/jsdetox
 #
 # To run this image after installing Docker, use the following command:
-# sudo docker run --rm -p 3000:3000 remnux/jsdetox
+# sudo docker run -d --rm --name jsdetox -p 3000:3000 remnux/jsdetox
 # Then, connect to http://localhost:3000 using your web browser.
-#
+# To stop jsdetox, use: 
+# sudo docker stop jsdetox
+# 
+# Updated for Ubuntu 18.04
+# Changes: Update version of therubyracer from 0.9.8 to 0.12.3
 
-FROM ubuntu:14.04
-MAINTAINER Lenny Zeltser (@lennyzeltser, www.zeltser.com)
+FROM ubuntu:18.04
+LABEL maintainer="Lenny Zeltser (@lennyzeltser, www.zeltser.com)"
+LABEL updated="1 May 2020"
 
 USER root
 RUN apt-get update && apt-get install -y \
@@ -30,6 +35,7 @@ RUN git clone https://github.com/svent/jsdetox.git
 
 USER root
 WORKDIR /home/nonroot/jsdetox
+RUN sed "s/, '0.9.8'/, '0.12.3'/g" -i Gemfile
 RUN bundle install
 
 USER nonroot

--- a/jsdetox/README.md
+++ b/jsdetox/README.md
@@ -2,11 +2,11 @@
 
 This Dockerfile represents a Docker image that encapsulates the [JSDetox][1] malware analysis tool for JavaScript deobfuscation by [@sven_t][2]. To run JSDetox after installing Docker, use the following command:
 
-    sudo docker run --rm -p 3000:3000 remnux/jsdetox
+    sudo docker run -d --rm --name jsdetox -p 3000:3000 remnux/jsdetox
 
-Then, connect to http://localhost:3000 using your web browser.
+Then, connect to http://localhost:3000 using your web browser. The startup process will take between 30 seconds to a minute.
 
-To stop JSDetox, use "`sudo docker ps -l`" to obtain the container ID, then use the "`sudo docker stop *container-id*`" and wait about a minute.
+To stop JSDetox, use "`sudo docker stop jsdetox`".
 
   [1]: http://www.relentless-coding.com/projects/jsdetox
   [2]: https://twitter.com/sven_t


### PR DESCRIPTION
Old version of therubyracer was causing issues with libv8 and Ubuntu 14 and 18. Changed version to allow for compatibility and proper function. Done using 'sed' command in docker to change the version to have minimal impact on the build process.
Also added ability to run it detached, name it, and stop it with docker stop.