### PR TITLE
Updated radare2 Docker

### DIFF
--- a/radare2/Dockerfile
+++ b/radare2/Dockerfile
@@ -1,65 +1,61 @@
+# Name: radare2
+# Website: https://www.radare.org/n/radare2.html
+# Description: Examine binary files, including disassembling and debugging.
+# Category: Dynamically Reverse-Engineer Code: General
+# Author: https://github.com/radareorg/radare2/blob/master/AUTHORS.md
+# License: GNU Lesser General Public License (LGPL) v3: https://github.com/radareorg/radare2/blob/master/COPYING
+# Notes: r2, rasm2, rabin2, rahash2, rafind2, r2agent
 #
-# This Docker image encapsulates the Radare2 reverse-engineering
-# framework available at http://radare.org.
+# This Dockerfile is modified for use in Ubuntu 18.04, but is based on 
+# the instructions documented in the official Radare2 Dockerfile file at
+# https://github.com/radareorg/radare2/blob/master/Dockerfile
 #
-# To run this image after installing Docker, use a command like this, replacing
-# "~/workdir" with the path to your working directory on the underlying host:
+# To run this image after installing Docker, use the command below, replacing
+# "~/workdir" with the path to your working directory on the underlying host.
+# Before running the docker, create ~/workdir on your host and make it
+# world-accessible ("chmod a+xwr").
 #
-# sudo docker run --rm -it -v ~/workdir:/home/nonroot/workdir remnux/radare2 bash
+# sudo docker run --rm -it --cap-drop=ALL --cap-add=SYS_PTRACE -v ~/workdir:/home/nonroot/workdir remnux/radare2
 #
 # Then run "r2" or other Radare2 commands inside the container.
 #
-# Before running the application, create ~/workdir on your host and make it
-# world-accessible ("chmod a+xwr").
-#
-# This Dockerfile is based on the instructions documented in the official
-# Radare2 Dockerfile file at
-# https://github.com/radare/radare2/blob/master/doc/Dockerfile.
-#
+# Running 'r2agent -a' will enable the web-based interface on port 8080 by default.
+# To access this, add '-p 8080:8080' to the above docker command (before 'remnux/radare2')
+# Then browse to your http://YOUR_IP:8080. 
 
-FROM ubuntu:14.04
-MAINTAINER Lenny Zeltser (@lennyzeltser, www.zeltser.com)
+FROM ubuntu:18.04
+LABEL maintainer="Lenny Zeltser (@lennyzeltser, www.zeltser.com)"
+LABEL updated="4 Aug 2020"
+LABEL updated_by="digitalsleuth"
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
 
 USER root
 RUN apt-get update && apt-get install -y \
-  software-properties-common \
-  python-all-dev \
-  curl \
-  swig \
-  flex \
-  bison \
-  git \
-  gcc \
-  g++ \
-  make \
-  pkg-config \
-  glib-2.0 \
-  python-gobject-dev \
-  valgrind \
-  gdb && \
+  sudo \
+  ccache \
+  wget \
+  build-essential \
+  git && \
   rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r nonroot && \
-  useradd -r -g nonroot -d /home/nonroot -s /sbin/nologin -c "Nonroot User" nonroot && \
-  mkdir /home/nonroot && \
-  chown -R nonroot:nonroot /home/nonroot
+  useradd -m -d /home/nonroot -g nonroot -s /sbin/nologin -c "Nonroot User" nonroot && \
+  mkdir -p /home/nonroot/workdir && \
+  chown -R nonroot:nonroot /home/nonroot && \
+  usermod -a -G sudo nonroot && echo 'nonroot:nonroot' | chpasswd
 
-ENV VALA_TAR vala-0.26.1
-WORKDIR /opt
-
-RUN curl -SL https://download.gnome.org/sources/vala/0.26/${VALA_TAR}.tar.xz | \
-  tar -JxC . && \
-  cd ${VALA_TAR}; ./configure --prefix=/usr && \
-  make && \
-  make install && \
-  cd .. && \
-  rm -rf ${VALA_TAR} && \
-  git clone https://github.com/radare/radare2.git && \
+RUN git clone https://github.com/radare/radare2.git && \
   cd radare2 && \
   ./sys/install.sh && \
-  mkdir /home/nonroot/workdir && \
-  chown nonroot:nonroot /home/nonroot/workdir
+  r2pm init && \
+  r2pm update
 
 USER nonroot
+ENV HOME /home/nonroot
+ENV USER nonroot
 WORKDIR /home/nonroot/workdir
-CMD ["r2"]
+VOLUME ["/home/nonroot/workdir"]
+EXPOSE 8080
+CMD ["/bin/bash"]

--- a/radare2/README.md
+++ b/radare2/README.md
@@ -2,12 +2,12 @@ This Docker image encapsulates the [Radare2][1] reverse-engineering framework.
 
 To run this image after installing Docker, use a command like this, replacing "~/workdir" with the path to your working directory on the underlying host:
 
-    sudo docker run --rm -it -v ~/workdir:/home/nonroot/workdir remnux/radare2 bash
+    sudo docker run --rm -it --cap-drop=ALL --cap-add=SYS_PTRACE -v ~/workdir:/home/nonroot/workdir remnux/radare2
 
-Then run `rd2` or other Radare2 commands inside the container. Before running the application, create ~/workdir on your host and make it world-accessible (`chmod a+xwr`).
+Then run `r2` or other Radare2 commands inside the container. Before running the application, create ~/workdir on your host and make it world-accessible (`chmod a+xwr`).
 
 This Dockerfile is based on the instructions documented in the official [Radare2 Dockerfile][2] file.
 
 
   [1]: http://radare.org/
-  [2]: https://github.com/radare/radare2/blob/master/doc/Dockerfile
+  [2]: https://github.com/radareorg/radare2/blob/master/Dockerfile


### PR DESCRIPTION
Updated the radare2 docker. Added the recommendations for cap-drop=ALL and cap-ad=SYS_PTRACE for debugging within the docker. Added UTF-8 ENV variables to avoid issues with decoding. Added sudo for nonroot user to manipulate files as required. Added /bin/bash as the effective CMD for the docker, so /bin/bash doesn't need to be executed from the docker command line.