### PR TITLE
Updated Rekall for python3

### DIFF
--- a/rekall/Dockerfile
+++ b/rekall/Dockerfile
@@ -1,64 +1,57 @@
+# Name: rekall 
+# Website: https://github.com/google/rekall
+# Description: Memory analysis framework Category: Examine memory snapshots
+# Author: https://github.com/google/rekall/blob/master/AUTHORS.md
+# License: https://github.com/google/rekall/blob/master/LICENSE.txt
+# Notes: rekall, rekal
+#
 # This is a rekall docker built on Ubuntu 18.04 LTS
 # The rekall software/source can be found either at
 # http://www.rekall-forensic.com or
 # https://github.com/google/rekall
 #
 # To use the docker, it is recommended to use the following command
-#  sudo docker run --rm -it -v <local_directory>:/home/nonroot/files remnux/rekall /bin/bash
+#  sudo docker run --rm -it -v <local_directory>:/home/nonroot/files remnux/rekall
 #
 # This will load you into the docker as the 'nonroot' user,
 # and allow you use run the command 'rekall' with any parameters required.
 
-FROM ubuntu:bionic
-LABEL version="1.4"
+FROM ubuntu:18.04
+LABEL version="2.0"
 LABEL description="Rekall docker based on Ubuntu 18.04 LTS"
 LABEL maintainer="https://github.com/digitalsleuth"
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
 
 USER root
 RUN apt-get update && apt-get install -y \
-  virtualenv \
-  nano \
-  git \
-  python \
-  python-pip \
-  python-dev \
+  sudo \
+  python3 \
+  python3-pip \
+  python3-dev \
   libssl-dev \
-  automake \
-  make \
-  gcc \
-  flex \
-  libtool \
-  bison \
-  pkg-config \
-  ncurses-dev && \
+  software-properties-common \
+  libncurses5-dev && \
+  add-apt-repository ppa:remnux/stable -y && apt-get update && apt-get install yara -y && \
   rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade setuptools pip wheel readline future==0.16.0 pybindgen pyaff4==0.26.post6 && \
-  rm /usr/bin/pip && ln -s /usr/local/bin/pip /usr/bin/pip && \
-  pip install fastchunking pyopenssl && \
-  pip install -q distorm3 && \
-  git clone https://github.com/VirusTotal/yara.git && \
-  cd yara && \
-  bash bootstrap.sh && \
-  bash configure && \
-  make && \
-  make install && \
-  make check && \
-  echo "/usr/local/lib" >> /etc/ld.so.conf && \
-  ldconfig && \
-  cd .. && \
-  rm -rf yara && \
-  pip install rekall-agent rekall && \
+RUN python3 -m pip install --upgrade setuptools pip wheel readline future==0.16.0 pybindgen pyaff4==0.26.post6 capstone && \
+  python3 -m pip install fastchunking pyopenssl && \
+  python3 -m pip install -q distorm3 && \
+  python3 -m pip install rekall-agent rekall && \
   apt-get autoremove -y --purge && \
   apt-get clean -y
 
-
 RUN groupadd -r nonroot && \
-  useradd -r -g nonroot -d /home/nonroot -s /sbin/nologin -c "Nonroot User" nonroot && \
-  mkdir /home/nonroot && \
-  chown -R nonroot:nonroot /home/nonroot
+  useradd -m -r -g nonroot -d /home/nonroot -s /sbin/nologin -c "Nonroot User" nonroot && \
+  mkdir -p /home/nonroot/files && \
+  chown -R nonroot:nonroot /home/nonroot && \
+  usermod -a -G sudo nonroot && echo 'nonroot:nonroot' | chpasswd
 
 USER nonroot
 ENV HOME /home/nonroot
-WORKDIR /home/nonroot
+WORKDIR /home/nonroot/files
+VOLUME ["/home/nonroot/files"]
 ENV USER nonroot
+CMD ["/bin/bash"]

--- a/rekall/README.md
+++ b/rekall/README.md
@@ -2,7 +2,7 @@
 
 This Dockerfile represents a Docker image that encapsulates the [Rekall Memory Forensic Framework][1]. To run this image after installing Docker, use a command like this:
 
-    sudo docker run --rm -it -v <local_directory>:/home/nonroot/files remnux/rekall bash
+    sudo docker run --rm -it -v <local_directory>:/home/nonroot/files remnux/rekall
 
 then run "`rekall`" in the container with the desired parameters.
 


### PR DESCRIPTION
Rekall now installs and works with python3. Configured docker to force C.UTF-8 environment (to avoid ascii decode errors). Added /bin/bash as final CMD variable to invoke rekall docker without requiring /bin/bash at command line.
Added REMnux repo to pull down current yara version.