### PR TITLE
Update Ciphey Dockerfile

### DIFF
--- a/ciphey/Dockerfile
+++ b/ciphey/Dockerfile
@@ -6,17 +6,18 @@
 # Notes: ciphey
 #
 # To run Ciphey using this Docker container, create a directory where you'll store
-# your input and output files. Then, use a command like this to open a shell inside
-# the container where you can run "ciphey" and have your directory mapped as
-# /home/nonroot/workdir inside the container:
+# your input files, e.g. ~/workdir/input.txt. Then, use a command like this to run "ciphey" 
+# and have your directory mapped as /home/nonroot/workdir inside the container:
 #
-# docker run -it --rm -v ~/workdir:/home/nonroot/workdir remnux/ciphey
+#   docker run -it --rm -v ~/workdir:/home/nonroot/workdir remnux/ciphey -f input.txt 
 #
-# The password for the container's user nonroot is nonroot. The remnux/ciphey image is
-# hosted on its its Docker Hub page.
+# Or for a text input: 
+#   docker run -it --rm remnux/ciphey "=MXazlHbh5WQgUmchdHbh1EIy9mZgQXarx2bvRFI4VnbpxEIBBiO4VnbNVkU"
+#
+# The remnux/ciphey image is hosted on its Docker Hub page.
 
-FROM ubuntu:18.04
-LABEL version="1.0"
+FROM python:3.8.5-slim-buster
+LABEL version="1.1"
 LABEL description="Ciphey - An Automated Decoding and Decryption Tool"
 LABEL maintainer="Lenny Zeltser"
 ENV LANG C.UTF-8
@@ -25,22 +26,17 @@ ENV LC_ALL C.UTF-8
 
 USER root
 
-RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  python3-pip sudo && \
-  rm -rf /var/lib/apt/lists/*
-
 RUN pip3 install --upgrade pip && \
-    python3 -m pip install ciphey
-
-RUN groupadd -r nonroot && \
+  pip3 install --upgrade ciphey && \
+  groupadd -r nonroot && \
   useradd -m -r -g nonroot -d /home/nonroot -s /usr/sbin/nologin -c "Nonroot User" nonroot && \
   mkdir -p /home/nonroot/workdir && \
-  chown -R nonroot:nonroot /home/nonroot && \
-  usermod -a -G sudo nonroot && echo 'nonroot:nonroot' | chpasswd
+  chown -R nonroot:nonroot /home/nonroot 
 
 USER nonroot
 ENV HOME /home/nonroot
 WORKDIR /home/nonroot/workdir
 VOLUME ["/home/nonroot/workdir"]
 ENV USER nonroot
-CMD ["/bin/bash"]
+ENTRYPOINT ["/usr/local/bin/ciphey"]
+CMD ["--help"]


### PR DESCRIPTION
This change should have no impact to the usability of the container or command, but with a significant decrease in size (down from 1.95GB to 164MB).
- Use the Official Python 3.8 slim docker image
- Remove nonroot user from sudo group, and remove unneeded password
- Add ENTRYPOINT to simplify running the ciphey command
- Add additional example to comments for file and text inputs

If the version of Ciphey that is currently in remnux/ciphey is desired, `ciphey==5.2.0` can be specified in the pip3 command, but 5.2.0 does not decode the example text input.

Ciphey does not yet include a way to save potential decrypted output to file(s), so references to output files were removed. Standard redirects and pipes will return to the host, not the container. It also includes comments, not just the potentially decrypted final result.