### PR TITLE
Pin SaltStack version in Dockerfiles to 3004

### DIFF
--- a/remnux-distro/Dockerfile.bionic
+++ b/remnux-distro/Dockerfile.bionic
@@ -36,7 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y wget gnupg git && \
     wget -nv -O - https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest/salt-archive-keyring.gpg | apt-key add - && \
-    echo deb [arch=amd64] https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest bionic main > /etc/apt/sources.list.d/saltstack.list && \
+    echo deb [arch=amd64] https://repo.saltproject.io/py3/ubuntu/18.04/amd64/3004 bionic main > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-common && \
     git clone https://github.com/REMnux/salt-states.git /srv/salt && \

--- a/remnux-distro/Dockerfile.focal
+++ b/remnux-distro/Dockerfile.focal
@@ -36,7 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y wget gnupg git && \
     wget -nv -O - https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest/salt-archive-keyring.gpg | apt-key add - && \
-    echo deb [arch=amd64] https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest focal main > /etc/apt/sources.list.d/saltstack.list && \
+    echo deb [arch=amd64] https://repo.saltproject.io/py3/ubuntu/20.04/amd64/3004 focal main > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-common && \
     git clone https://github.com/REMnux/salt-states.git /srv/salt && \


### PR DESCRIPTION
To prevent accidental upgrade for anyone who decides to build from the Dockerfile, I've pinned the version of SaltStack to 3004. This should prevent any issues which could arise from the next Salt Release.